### PR TITLE
Removing Visual Studio 2015 from documentation as it is not supported anymore

### DIFF
--- a/docs_md/Join-the-project-as-a-developer-be6ef085e89f49038c2b671c0743b690.md
+++ b/docs_md/Join-the-project-as-a-developer-be6ef085e89f49038c2b671c0743b690.md
@@ -1,14 +1,14 @@
-# [Documentation](/docs/) : Join the project as a developer
+# [Documentation](/docs/): Join the project as a developer
 
 SumatraPDF is an open-source, [collaborative](https://github.com/sumatrapdfreader/sumatrapdf/blob/master/AUTHORS) project. We always welcome new developers who want to join the project, contribute code and new features.
 
 ## Getting the sources and compiling
 
-You'll need Visual Studio 2017 or 2015. A [free Community edition](https://www.visualstudio.com/vs/community/) will work.
+You'll need Visual Studio 2017. A [free Community edition](https://www.visualstudio.com/vs/community/) will work.
 
 Get the sources from [https://github.com/sumatrapdfreader/sumatrapdf](https://github.com/sumatrapdfreader/sumatrapdf)
 
-Open `vs2017/SumatraPDF.sln` or `vs2015/SumatraPDF.sln` , compile and run.
+Open `vs2017/SumatraPDF.sln`, compile and run.
 
 ## How to join SumatraPDF project
 
@@ -22,4 +22,4 @@ Before you start working on a significant addition, it's a good idea to first di
 
 ## Questions?
 
-You can use [issue tracker](https://github.com/sumatrapdfreader/sumatrapdf/issues) for development related topics or [forums](https://forum.sumatrapdfreader.org/ for general topics.
+You can use [issue tracker](https://github.com/sumatrapdfreader/sumatrapdf/issues) for development related topics or [forums](https://forum.sumatrapdfreader.org/) for general topics.

--- a/www/docs/Join-the-project-as-a-developer.html
+++ b/www/docs/Join-the-project-as-a-developer.html
@@ -27,17 +27,17 @@
 
 		<div id="center">
 			<div class="content">
-				<h1><a href="/docs/">Documentation</a> : Join the project as a developer</h1>
+				<h1><a href="/docs/">Documentation</a>: Join the project as a developer</h1>
 
 <p>SumatraPDF is an open-source, <a href="https://github.com/sumatrapdfreader/sumatrapdf/blob/master/AUTHORS">collaborative</a> project. We always welcome new developers who want to join the project, contribute code and new features.</p>
 
 <h2>Getting the sources and compiling</h2>
 
-<p>You&rsquo;ll need Visual Studio 2017 or 2015. A <a href="https://www.visualstudio.com/vs/community/">free Community edition</a> will work.</p>
+<p>You&rsquo;ll need Visual Studio 2017. A <a href="https://www.visualstudio.com/vs/community/">free Community edition</a> will work.</p>
 
 <p>Get the sources from <a href="https://github.com/sumatrapdfreader/sumatrapdf">https://github.com/sumatrapdfreader/sumatrapdf</a></p>
 
-<p>Open <code>vs2017/SumatraPDF.sln</code> or <code>vs2015/SumatraPDF.sln</code> , compile and run.</p>
+<p>Open <code>vs2017/SumatraPDF.sln</code>, compile and run.</p>
 
 <h2>How to join SumatraPDF project</h2>
 


### PR DESCRIPTION
Visual Studio 2015 has been removed as supported build environment by commit sumatrapdfreader/sumatrapdf@6574ea4e692dc1b9472716fbf0d80bb3169025a2 on November 7, 2017. This PR reflects this in the documentation, too.

I am not sure if I have done everything right, because I am a bit confused of this repository to be honest. It is not clear to me if the HTML pages below `www` are automatically generated from the Markdown files in `docs_md`. If so, it is not clear to me why build artifacts are committed into this repo, too.

I am missing any instructions how to work with the go build system that seems to be used to do this. I am not able to properly run the go package on my Ubuntu system, but noticed that there are PowerShell scripts inside the `s` folder. So I assume that the developer is mainly working on Windows systems to build the documentation.

Anyway, please let me know if any changes are required because I misunderstood this whole concept.