### PR TITLE
Keyboard shortcuts - Bookmarks section - add collapse & expand

### DIFF
--- a/www/manual.html
+++ b/www/manual.html
@@ -188,15 +188,6 @@
                                     <td>&nbsp;rotate right</td>
                                 </tr>
                                 <tr>
-                                    <td align="right"><b>F12</b></td>
-                                    <td>&nbsp;show/hide bookmarks (table of contents)</td>
-                                </tr>
-                                <tr>
-                                    <td align="right"><b>F6</b>
-                                    </td>
-                                    <td>&nbsp;switch focus between bookmarks window and main window</td>
-                                </tr>
-                                <tr>
                                     <td align="right"><b>&lt;Ctrl&gt;</b> + <b>L</b> or <b>F11</b></td>
                                     <td>&nbsp;enter presentation mode (minimal full screen mode)</td>
                                 </tr>
@@ -241,6 +232,31 @@
                                     <td align="right"><b>F9</b>
                                     </td>
                                     <td>&nbsp;show/hide menu</td>
+                                </tr>
+                                <tr>
+                                    <td>&nbsp;</td>
+                                    <td></td>
+                                </tr>
+                                <tr>
+                                    <td></td>
+                                    <td><b>Bookmarks</b></td>
+                                </tr>
+                                <tr>
+                                    <td align="right"><b>F12</b></td>
+                                    <td>&nbsp;show/hide bookmarks (table of contents)</td>
+                                </tr>
+                                <tr>
+                                    <td align="right"><b>F6</b>
+                                    </td>
+                                    <td>&nbsp;switch focus between bookmarks window and main window</td>
+                                </tr>
+                                <tr>
+                                    <td align="right"><b>&lt;Shift&gt; + &lt;Numpad /&gt;</b></td>
+                                    <td>&nbsp;collapse all bookmarks</td>
+                                </tr>
+                                <tr>
+                                    <td align="right"><b>&lt;Shift&gt; + &lt;Numpad *&gt;</b></td>
+                                    <td>&nbsp;expand all bookmarks</td>
                                 </tr>
 
                                 <tr>


### PR DESCRIPTION
Hi

i found in the issue tracker there exists 2 keyboard shortcuts to expand / collapse the bookmarks tree.
https://github.com/sumatrapdfreader/sumatrapdf/issues/718

I added them to the keyboard shortcuts list in the main manual page.

